### PR TITLE
[otel/kube-stack] Update EDOT SDK k8s auto-instrumentation images to their latest versions

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -616,6 +616,6 @@ instrumentation:
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
-    image: docker.elastic.co/observability/elastic-otel-python:1.2.0
+    image: docker.elastic.co/observability/elastic-otel-python:1.7.0
   go:
     image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -610,7 +610,7 @@ instrumentation:
     type: parentbased_traceidratio # Sampler type
     argument: "1.0" # Sampling rate set to 100% (all traces are sampled).
   java:
-    image: docker.elastic.co/observability/elastic-otel-javaagent:1.2.1
+    image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
   nodejs:
     image: docker.elastic.co/observability/elastic-otel-node:1.1.0
   dotnet:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -618,4 +618,4 @@ instrumentation:
   python:
     image: docker.elastic.co/observability/elastic-otel-python:1.2.0
   go:
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -50,7 +50,7 @@ collectors:
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/eks:
-          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -58,11 +58,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -219,7 +219,7 @@ collectors:
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/eks:
-          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -227,11 +227,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -244,7 +244,7 @@ collectors:
               from_attribute: k8s.node.name
               action: upsert
         resourcedetection/system:
-          detectors: ["system", "ec2"] # Detects resources from the system and EC2 instances.
+          detectors: ["system", "ec2"]
           system:
             hostname_sources: ["os"]
             resource_attributes:
@@ -614,7 +614,7 @@ instrumentation:
   nodejs:
     image: docker.elastic.co/observability/elastic-otel-node:1.1.0
   dotnet:
-    image: docker.elastic.co/observability/elastic-otel-dotnet:1.0.0
+    image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
     image: docker.elastic.co/observability/elastic-otel-python:1.2.0
   go:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -612,7 +612,7 @@ instrumentation:
   java:
     image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
   nodejs:
-    image: docker.elastic.co/observability/elastic-otel-node:1.1.0
+    image: docker.elastic.co/observability/elastic-otel-node:1.2.0
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -591,6 +591,6 @@ instrumentation:
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
-    image: docker.elastic.co/observability/elastic-otel-python:1.2.0
+    image: docker.elastic.co/observability/elastic-otel-python:1.7.0
   go:
     image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -593,4 +593,4 @@ instrumentation:
   python:
     image: docker.elastic.co/observability/elastic-otel-python:1.2.0
   go:
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -50,7 +50,7 @@ collectors:
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/eks:
-          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -58,11 +58,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -191,14 +191,14 @@ collectors:
             insecure: true
       processors:
         # [Batch Processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)
-        batch: {} # inherit any values from helm chart
+        batch: {}
         batch/metrics:
           # explicitly set send_batch_max_size to 0, as splitting metrics requests may cause version_conflict_engine_exception in TSDB
           send_batch_max_size: 0
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/eks:
-          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -206,11 +206,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -223,7 +223,7 @@ collectors:
               from_attribute: k8s.node.name
               action: upsert
         resourcedetection/system:
-          detectors: ["system", "ec2"] # Detects resources from the system and EC2 instances.
+          detectors: ["system", "ec2"]
           system:
             hostname_sources: ["os"]
             resource_attributes:
@@ -536,7 +536,7 @@ collectors:
           send_batch_max_size: 0
           timeout: 1s
         # [Elastic Trace Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor)
-        elastictrace: {} # The processor enriches traces with elastic specific requirements.
+        elastictrace: {}
       exporters:
         debug: {}
         # [Elasticsearch exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/elasticsearchexporter/README.md)
@@ -589,7 +589,7 @@ instrumentation:
   nodejs:
     image: docker.elastic.co/observability/elastic-otel-node:1.1.0
   dotnet:
-    image: docker.elastic.co/observability/elastic-otel-dotnet:1.0.0
+    image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
     image: docker.elastic.co/observability/elastic-otel-python:1.2.0
   go:

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -587,7 +587,7 @@ instrumentation:
   java:
     image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
   nodejs:
-    image: docker.elastic.co/observability/elastic-otel-node:1.1.0
+    image: docker.elastic.co/observability/elastic-otel-node:1.2.0
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -585,7 +585,7 @@ instrumentation:
     type: parentbased_traceidratio # Sampler type
     argument: "1.0" # Sampling rate set to 100% (all traces are sampled).
   java:
-    image: docker.elastic.co/observability/elastic-otel-javaagent:1.2.1
+    image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
   nodejs:
     image: docker.elastic.co/observability/elastic-otel-node:1.1.0
   dotnet:


### PR DESCRIPTION


Update the versions of the EDOT language SDK images being used with the OTel Operator.


---



<Actions>
    <action id="901223529a6beca5c9cb3180f1dae9731c8da4e9c40169d7042cc0163a6d7e24">
        <h3>Bump golang-version to latest version</h3>
        <details id="16b310b2eddb2a35f9bf1f37435b39a5c4060b26fc5e9524aae985d624e61a5e">
            <summary>Update OpenTelemetry Go Instrumentation image in values.yaml</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.instrumentation.go.image&#34; updated from &#34;ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0&#34; to &#34;ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml&#34;&#xA;* key &#34;$.instrumentation.go.image&#34; updated from &#34;ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.21.0&#34; to &#34;ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/values.yaml&#34;</p>
            <details>
                <summary>v0.22.1</summary>
                <pre>## Overview&#xD;&#xA;&#xD;&#xA;### Added&#xD;&#xA;&#xD;&#xA;- Cache offsets for `google.golang.org/grpc` `1.71.3`. ([#2374](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2374))&#xD;&#xA;- Cache offsets for `google.golang.org/grpc` `1.72.2`. ([#2374](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2374))&#xD;&#xA;- Cache offsets for `golang.org/x/net` `0.41.0`. ([#2402](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2402))&#xD;&#xA;- Cache offsets for `google.golang.org/grpc` `1.73.0`. ([#2402](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2402))&#xD;&#xA;- Cache offsets for Go `1.23.10`. ([#2402](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2402))&#xD;&#xA;- Cache offsets for Go `1.24.4`. ([#2402](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2402))&#xD;&#xA;- Cache offsets for `go.opentelemetry.io/otel` `v1.37.0`. ([#2450](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2450))&#xD;&#xA;- Cache offsets for `google.golang.org/grpc` `1.75.0-dev`. ([#2450](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2450))&#xD;&#xA;&#xD;&#xA;### Fixed&#xD;&#xA;&#xD;&#xA;- Build go binaries using the provided `TARGETARCH` of the Dockerfile.&#xD;&#xA;  This fixes the bug where images for alternate architectures (e.g. `arm64`) were built using the `amd64` architecture. ([#2411](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2411))&#xD;&#xA;- Do not fail run when a module has a version of `(devel)`. ([#2437](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2437))&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;* chore(deps): update module github.com/sashamelentyev/usestdlibvars to v1.29.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2371&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to e3ca7f9 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2372&#xD;&#xA;* [auto] Update generated offsets by @github-actions in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2374&#xD;&#xA;* fix(deps): update module google.golang.org/grpc to v1.72.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2373&#xD;&#xA;* chore(deps): update module github.com/golangci/plugin-module-register to v0.1.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2377&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 4cab0e6 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2375&#xD;&#xA;* fix(deps): update module go.opentelemetry.io/collector/pdata to v1.33.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2376&#xD;&#xA;* chore(deps): update module github.com/ugorji/go/codec to v1.2.14 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2378&#xD;&#xA;* chore(deps): update docker/build-push-action action to v6.18.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2379&#xD;&#xA;* chore(deps): update googleapis to 200df99 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2384&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to ec4810c by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2380&#xD;&#xA;* chore(deps): update module github.com/abirdcfly/dupword to v0.1.5 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2381&#xD;&#xA;* chore(deps): update module github.com/go-logr/logr to v1.4.3 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2385&#xD;&#xA;* chore(deps): update bitnami/kafka:latest docker digest to a5182b6 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2389&#xD;&#xA;* chore(deps): update module github.com/abirdcfly/dupword to v0.1.6 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2387&#xD;&#xA;* fix(deps): update module github.com/docker/docker to v28.2.1+incompatible by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2386&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 4275c5b by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2391&#xD;&#xA;* chore(deps): update module go.opentelemetry.io/proto/otlp to v1.7.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2390&#xD;&#xA;* chore(deps): update bitnami/kafka:latest docker digest to 6cd4f5e by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2392&#xD;&#xA;* chore(deps): update golang.org/x to 65e9200 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2394&#xD;&#xA;* chore(deps): update ossf/scorecard-action action to v2.4.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2395&#xD;&#xA;* fix(deps): update module github.com/docker/docker to v28.2.2+incompatible by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2393&#xD;&#xA;* [auto] Update generated offsets by @github-actions in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2402&#xD;&#xA;* chore(deps): update gcr.io/distroless/base-debian12 docker digest to 201ef91 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2410&#xD;&#xA;* fix(deps): update golang.org/x by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2396&#xD;&#xA;* chore(deps): update golang:1.24.3 docker digest to 81bf592 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2397&#xD;&#xA;* chore(deps): update googleapis to 513f239 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2403&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 9c62b1c by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2404&#xD;&#xA;* chore(deps): update golang docker tag to v1.24.4 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2406&#xD;&#xA;* chore(deps): update module github.com/bytedance/sonic to v1.13.3 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2407&#xD;&#xA;* chore(deps): update module github.com/go-git/go-git/v5 to v5.16.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2408&#xD;&#xA;* chore(deps): update github/codeql-action action to v3.29.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2405&#xD;&#xA;* chore(deps): update jaegertracing/all-in-one docker tag to v1.70.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2416&#xD;&#xA;* chore(deps): update python docker tag to v3.13.5 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2409&#xD;&#xA;* chore(deps): update module github.com/ldez/exptostd to v0.4.4 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2412&#xD;&#xA;* chore(deps): update module github.com/securego/gosec/v2 to v2.22.5 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2414&#xD;&#xA;* chore(deps): update docker/setup-buildx-action action to v3.11.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2415&#xD;&#xA;* chore(deps): update jaegertracing/jaeger docker tag to v2.7.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2417&#xD;&#xA;* chore(deps): update module github.com/go-viper/mapstructure/v2 to v2.3.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2418&#xD;&#xA;* chore(deps): update module github.com/ldez/gomoddirectives to v0.7.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2419&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to e5de1e2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2420&#xD;&#xA;* chore(deps): update module github.com/ldez/usetesting to v0.5.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2421&#xD;&#xA;* chore(deps): update module github.com/sergi/go-diff to v1.4.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2422&#xD;&#xA;* chore(deps): update module github.com/spf13/cast to v1.9.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2423&#xD;&#xA;* chore(deps): update module github.com/ugorji/go/codec to v1.3.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2424&#xD;&#xA;* fix(deps): update module google.golang.org/grpc to v1.73.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2427&#xD;&#xA;* fix(deps): update module go.opentelemetry.io/collector/pdata to v1.34.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2425&#xD;&#xA;* Update CHANGELOG and COMPATIBILITY for #2402 by @MrAlias in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2413&#xD;&#xA;* chore(deps): update module github.com/charmbracelet/x/ansi to v0.9.3 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2428&#xD;&#xA;* Set docker build args to environment variables by @MrAlias in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2411&#xD;&#xA;* chore(deps): update docker/setup-buildx-action action to v3.11.1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2431&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 0100d21 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2433&#xD;&#xA;* chore(deps): update golang.org/x to b7579e2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2435&#xD;&#xA;* chore(deps): update module github.com/grpc-ecosystem/grpc-gateway/v2 to v2.27.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2429&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to bdbe6a2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2440&#xD;&#xA;* chore(deps): update module github.com/prometheus/common to v0.65.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2439&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 20bd1e7 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2441&#xD;&#xA;* Split the `utils` package by @MrAlias in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2436&#xD;&#xA;* Handle &#34;(devel)&#34; version modules by @MrAlias in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2437&#xD;&#xA;* chore(deps): update module github.com/mgechev/revive to v1.10.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2382&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 15299cc by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2442&#xD;&#xA;* chore(deps): update module github.com/grpc-ecosystem/grpc-gateway/v2 to v2.27.1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2443&#xD;&#xA;* Update community member listings by @opentelemetrybot in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2445&#xD;&#xA;* [auto] Update generated offsets by @github-actions in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2450&#xD;&#xA;* fix(deps): update module github.com/docker/docker to v28.3.0+incompatible by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2444&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to 6207142 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2446&#xD;&#xA;* chore(deps): update module github.com/sonatard/noctx to v0.3.4 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2447&#xD;&#xA;* chore(deps): update module github.com/klauspost/cpuid/v2 to v2.2.11 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2448&#xD;&#xA;* fix(deps): update opentelemetry-go-contrib monorepo to v0.62.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2451&#xD;&#xA;* fix(deps): update opentelemetry-go monorepo to v1.37.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2449&#xD;&#xA;* fix(deps): update module github.com/cilium/ebpf to v0.19.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2452&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to dd718e4 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2453&#xD;&#xA;* Fix outdated community membership link by @opentelemetrybot in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2454&#xD;&#xA;* chore(deps): update github/codeql-action action to v3.29.1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2455&#xD;&#xA;* fix(deps): update module github.com/masterminds/semver/v3 to v3.4.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2456&#xD;&#xA;* fix(deps): update module github.com/golangci/golangci-lint/v2 to v2.2.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2458&#xD;&#xA;* fix(deps): update module github.com/golangci/golangci-lint/v2 to v2.2.1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2459&#xD;&#xA;* chore(deps): update github/codeql-action action to v3.29.2 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2460&#xD;&#xA;* fix(deps): update module go.opentelemetry.io/collector/pdata to v1.35.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2461&#xD;&#xA;* chore(deps): update module github.com/uudashr/iface to v1.4.1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2462&#xD;&#xA;* chore(deps): update module github.com/alecthomas/chroma/v2 to v2.19.0 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2463&#xD;&#xA;* chore(deps): update golang:1.24.4 docker digest to 1bb140b by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2465&#xD;&#xA;* chore(deps): update python:3.13.5-slim-bullseye docker digest to 631af3f by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2467&#xD;&#xA;* chore(deps): update golang:1.24.4-bookworm docker digest to 8faa537 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2466&#xD;&#xA;* fix(deps): update google.golang.org/grpc/examples digest to bb4b6d5 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2468&#xD;&#xA;* chore(deps): update golang:1.24.4 docker digest to 1aa97dd by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2470&#xD;&#xA;* [chore] Add minimum token permissions for all github workflow files by @opentelemetrybot in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2464&#xD;&#xA;* chore(deps): update golang:1.24.4 docker digest to a92f3b1 by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2472&#xD;&#xA;* chore(deps): update golang:1.24.4-bookworm docker digest to 2b85dcb by @renovate in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2473&#xD;&#xA;* Release v0.22.1 by @MrAlias in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2471&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.22.0...v0.22.1</pre>
            </details>
        </details>
        <details id="4edeb39b52e515a4710bf21c61d07c5c1879c0ce9676228fa2353045cb439f71">
            <summary>Update Elastic OTEL Java image in values.yaml</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.instrumentation.java.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-javaagent:1.2.1&#34; to &#34;docker.elastic.co/observability/elastic-otel-javaagent:1.5.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml&#34;&#xA;* key &#34;$.instrumentation.java.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-javaagent:1.2.1&#34; to &#34;docker.elastic.co/observability/elastic-otel-javaagent:1.5.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/values.yaml&#34;</p>
            <details>
                <summary>v1.5.0</summary>
                <pre>* Add support of `elastic.otel.verify.server.cert` config option to disable server certificate validation - #726&#xD;&#xA;* tech preview release of central configuration support for dynamically changing instrumentation and sending, using OpAMP protocol&#xD;&#xA;&#xD;&#xA;This release is based on the following upstream versions:&#xD;&#xA;&#xD;&#xA;* opentelemetry-javaagent: [2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1)&#xD;&#xA;* opentelemetry-sdk: [1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0)&#xD;&#xA;* opentelemetry-semconv: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)&#xD;&#xA;* opentelemetry-java-contrib: [1.46.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.46.0)</pre>
            </details>
        </details>
        <details id="a8e1d0543b6883fddc7de3f80782e6014eb8361748200410257456e3829f8172">
            <summary>Update Elastic OTEL .NET image in values.yaml</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.instrumentation.dotnet.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-dotnet:1.0.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-dotnet:1.1.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml&#34;&#xA;* key &#34;$.instrumentation.dotnet.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-dotnet:1.0.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-dotnet:1.1.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/values.yaml&#34;</p>
            <details>
                <summary>1.1.0</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;* Update to 1.12.x upstream packages by @stevejgordon in https://github.com/elastic/elastic-otel-dotnet/pull/287&#xD;&#xA;* Treat EventLevel.Verbose as debug log level by @stevejgordon in https://github.com/elastic/elastic-otel-dotnet/pull/288&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @theletterf made their first contribution in https://github.com/elastic/elastic-otel-dotnet/pull/271&#xD;&#xA;* @oakrizan made their first contribution in https://github.com/elastic/elastic-otel-dotnet/pull/286&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/elastic-otel-dotnet/compare/1.0.2...1.1.0</pre>
            </details>
        </details>
        <details id="b473b680e44600e09d845b794b23f42b0349e6d8e91a5793a12f1b7a00e5154f">
            <summary>Update Elastic OTEL Python image in managed_otlp/values.yaml</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.instrumentation.python.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-python:1.2.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-python:1.7.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml&#34;&#xA;* key &#34;$.instrumentation.python.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-python:1.2.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-python:1.7.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/values.yaml&#34;</p>
            <details>
                <summary>v1.7.0</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;- distro: handle dynamic tracing sampling rate from central config (requires stack 9.2) (#367)&#xD;&#xA;- Bump OpenTelemetry to 1.36.0/0.57b0 (#373)&#xD;&#xA;&#xD;&#xA;  Upstream changes:&#xD;&#xA;  * https://github.com/open-telemetry/opentelemetry-python/discussions/4706&#xD;&#xA;  * https://github.com/open-telemetry/opentelemetry-python-contrib/discussions/3710&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/elastic-otel-python/compare/v1.6.0...v1.7.0</pre>
            </details>
        </details>
        <details id="b59a48b80238a750c18fdfa29614716cf56f2ecc363ac81ed21337b397abee1e">
            <summary>Update Elastic OTEL Node.js image in values.yaml</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.instrumentation.nodejs.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-node:1.1.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-node:1.2.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml&#34;&#xA;* key &#34;$.instrumentation.nodejs.image&#34; updated from &#34;docker.elastic.co/observability/elastic-otel-node:1.1.0&#34; to &#34;docker.elastic.co/observability/elastic-otel-node:1.2.0&#34;, in file &#34;deploy/helm/edot-collector/kube-stack/values.yaml&#34;</p>
            <details>
                <summary>v1.2.0</summary>
                <pre>## Changelog&#xA;&#xA;### Features and enhancements&#xA;&#xA;- Initial support for Central Configuration: the ability to configure some aspects of EDOT Node.js in running instrumented applications from a central Kibana. This feature is in technical preview. [#834](https://github.com/elastic/elastic-otel-node/pull/834) [#886](https://github.com/elastic/elastic-otel-node/pull/886)&#xA;&#xA;  This release includes support for the following settings: `logging_level`, `deactivate_all_instrumentations`, `deactivate_instrumentations`&#xA;&#xA;### Chores&#xA;&#xA;- Support for instrumenting `redis` version 4 has moved from `@opentelemetry/instrumentation-redis-4` to `@opentelemetry/instrumentation-redis`. If you are using the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` or `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variables to control instrumentation of `redis@4` you will need to change from using &#34;redis-4&#34; to &#34;redis&#34;.&#xA;&#xA;---&#xA;&#xA;[README](https://github.com/elastic/elastic-otel-node/tree/main/packages/opentelemetry-node#readme) | [Full Release Notes](https://github.com/elastic/elastic-otel-node/blob/main/docs/release-notes/index.md) | [Breaking Changes](https://github.com/elastic/elastic-otel-node/blob/main/docs/release-notes/breaking-changes.md)&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

